### PR TITLE
Quick fixes for quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ on XenServer / XCP-ng pools as Kubernetes worker and control plane nodes.
 CLUSTER_TOPOLOGY=true clusterctl init --bootstrap kubeadm --control-plane kubeadm
 
 # 2. Deploy the vates provider
-kubectl apply -f https://github.com/vatesfr/cluster-api-provider-vates/releases/latest/download/install.yaml
-
+kubectl apply -f https://raw.githubusercontent.com/vatesfr/cluster-api-provider-vates/refs/heads/main/dist/install.yaml
 # 3. Create the XO credentials secret
 kubectl create secret generic xo-credentials -n capi-system \
   --from-literal=url="https://<your-xoa>" \
@@ -28,18 +27,30 @@ All templates must have **cloud-init** support enabled and **Xen guest tools** i
 
 Two ClusterClass variants are provided:
 
-- **`prefilled`** — for templates that already have kubelet, kubeadm, containerd, kube-vip, and Cilium images pre-installed. Edit `examples/machinetemplates/prefilled/`.
-- **`from-scratch`** — for minimal templates (just containerd + Xen guest tools). The ClusterClass handles installing everything via `preKubeadmCommands`. Edit `examples/machinetemplates/from-scratch/`.
+- **`prefilled`** — for templates that already have kubelet, kubeadm, containerd, kube-vip, and Cilium images pre-installed. Edit `templates/machinetemplates/prefilled/`.
+- **`from-scratch`** — for minimal templates (just containerd + Xen guest tools). The ClusterClass handles installing everything via `preKubeadmCommands`. Edit `templates/machinetemplates/from-scratch/`.
 
-Edit the matching `VatesMachineTemplate` files to set your `templateID`, `poolID`, and network name, then apply:
+
+Edit the matching `VatesMachineTemplate` files to set your `templateID`, `poolID`, and network name.
+
+Note: TemplateID is without PoolID in it and must be bootable
 
 ```bash
 # 4. Deploy ClusterClass + machine templates
-kubectl apply -k examples/clusterclass/
-kubectl apply -k examples/machinetemplates/prefilled/
+kubectl apply -k templates/clusterclass/
 
+# Choose only one:
+# For prefilled machine templates
+kubectl apply -k templates/machinetemplates/prefilled/
+# For from scratch machine templates
+kubectl apply -k templates/machinetemplates/from-scratch
+```
+
+Edit the example, then apply:
+
+```
 # 5. Create a cluster
-kubectl apply -f examples/example-cluster/capi-cluster.yaml
+kubectl apply -f templates/example-cluster/capi-cluster.yaml
 ```
 
 ## Development

--- a/templates/clusterclass/from-scratch/rhel-from-scratch-control-plane.yaml
+++ b/templates/clusterclass/from-scratch/rhel-from-scratch-control-plane.yaml
@@ -36,7 +36,7 @@ spec:
           - sysctl --system
           - swapoff -a; sed -i '/ swap /d' /etc/fstab 2>/dev/null; true
           - dnf install -y epel-release
-          - dnf install -y containerd
+          - dnf install -y containerd runc
           - containerd config default | sed 's/SystemdCgroup = false/SystemdCgroup = true/' | tee /etc/containerd/config.toml
           - mkdir -p /etc/containerd/certs.d/registry.k8s.io && printf 'server = "https://registry.k8s.io"\n\n[host."https://mirror.gcr.io"]\n  capabilities = ["pull", "resolve"]\n' > /etc/containerd/certs.d/registry.k8s.io/hosts.toml
           - systemctl enable --now containerd

--- a/templates/clusterclass/from-scratch/rhel-from-scratch-control-plane.yaml
+++ b/templates/clusterclass/from-scratch/rhel-from-scratch-control-plane.yaml
@@ -16,11 +16,15 @@ spec:
             kubeletExtraArgs:
               - name: cgroup-driver
                 value: systemd
+              - name: cloud-provider
+                value: external
         joinConfiguration:
           nodeRegistration:
             kubeletExtraArgs:
               - name: cgroup-driver
                 value: systemd
+              - name: cloud-provider
+                value: external
         preKubeadmCommands:
           - |
             IP=$(hostname -I | awk '{print $1}')

--- a/templates/clusterclass/from-scratch/rhel-from-scratch-worker.yaml
+++ b/templates/clusterclass/from-scratch/rhel-from-scratch-worker.yaml
@@ -16,7 +16,7 @@ spec:
         - sysctl --system
         - swapoff -a; sed -i '/ swap /d' /etc/fstab 2>/dev/null; true
         - dnf install -y epel-release
-        - dnf install -y containerd
+        - dnf install -y containerd runc
         - containerd config default | sed 's/SystemdCgroup = false/SystemdCgroup = true/' | tee /etc/containerd/config.toml
         - mkdir -p /etc/containerd/certs.d/registry.k8s.io && printf 'server = "https://registry.k8s.io"\n\n[host."https://mirror.gcr.io"]\n  capabilities = ["pull", "resolve"]\n' > /etc/containerd/certs.d/registry.k8s.io/hosts.toml
         - systemctl enable --now containerd

--- a/templates/clusterclass/from-scratch/rhel-from-scratch-worker.yaml
+++ b/templates/clusterclass/from-scratch/rhel-from-scratch-worker.yaml
@@ -42,3 +42,5 @@ spec:
           kubeletExtraArgs:
             - name: cgroup-driver
               value: systemd
+            - name: cloud-provider
+              value: external


### PR DESCRIPTION
I setup correctly CAPI using microk8s XO receipe and from scratch template with Alma 9 cloud init template by following README documentation.

However, I needed to make quick fixes :
- The link of install.md is incorrect because there is no release, just tags
- Fixed the examples/template commands
- Runc was not present in alma 9 cloud init template 
- CCM must be declared as external also in from-scratch, not only in pre-fill